### PR TITLE
Add Runpod configuration UI and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.DS_Store
+*.log

--- a/index.html
+++ b/index.html
@@ -12,13 +12,16 @@
     <div class="container">
       <header>
         <h1 id="title">AI Image Generator</h1>
-        <div class="language-selector">
-          <select id="languageSelect" onchange="changeLanguage(this.value)">
-            <option value="en">English</option>
-            <option value="sv">Svenska</option>
-            <option value="de">Deutsch</option>
-            <option value="es">Español</option>
-          </select>
+        <div class="header-right">
+          <button id="configBtn">⚙️ Config</button>
+          <div class="language-selector">
+            <select id="languageSelect" onchange="changeLanguage(this.value)">
+              <option value="en">English</option>
+              <option value="sv">Svenska</option>
+              <option value="de">Deutsch</option>
+              <option value="es">Español</option>
+            </select>
+          </div>
         </div>
       </header>
       
@@ -169,6 +172,28 @@
 
       <button id="runBtn">🚀 Generate Image</button>
       <div id="output"></div>
+    </div>
+
+    <div id="configModal" class="modal hidden">
+      <div class="modal-content">
+        <h2>API Configuration</h2>
+        <label for="serviceSelect">Service:</label>
+        <select id="serviceSelect">
+          <option value="runpod">Runpod</option>
+        </select>
+        <div class="form-group">
+          <label for="runpodId">Runpod ID:</label>
+          <input type="text" id="runpodId" />
+        </div>
+        <div class="form-group">
+          <label for="runpodKey">Runpod Key:</label>
+          <input type="text" id="runpodKey" />
+        </div>
+        <div class="modal-actions">
+          <button id="saveConfig">Save</button>
+          <button id="closeConfig">Close</button>
+        </div>
+      </div>
     </div>
 
     <script src="js/config.js"></script>

--- a/js/config.js
+++ b/js/config.js
@@ -24,3 +24,32 @@ const DEFAULT_VALUES = {
   seed: "42",
   scheduler: "K_EULER"
 };
+
+const CONFIG_STORAGE_KEY = 'apiConfig';
+
+function applyConfig(cfg) {
+  if (cfg && cfg.service === 'runpod' && cfg.runpodId && cfg.runpodKey) {
+    CONFIG.API_KEY = cfg.runpodKey;
+    CONFIG.ENDPOINT = `https://api.runpod.ai/v2/${cfg.runpodId}/run`;
+    CONFIG.STATUS_ENDPOINT = `https://api.runpod.ai/v2/${cfg.runpodId}/status/`;
+  }
+}
+
+function loadSavedConfig() {
+  try {
+    const stored = localStorage.getItem(CONFIG_STORAGE_KEY);
+    if (stored) {
+      const cfg = JSON.parse(stored);
+      applyConfig(cfg);
+    }
+  } catch (e) {
+    console.error('Failed to load config', e);
+  }
+}
+
+function saveConfig(cfg) {
+  localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(cfg));
+  applyConfig(cfg);
+}
+
+loadSavedConfig();

--- a/js/main.js
+++ b/js/main.js
@@ -8,10 +8,13 @@ document.addEventListener('DOMContentLoaded', function() {
   
   // Initialize form with default values
   initializeForm();
-  
+
   // Initialize range value displays
   initializeRangeValues();
-  
+
+  // Initialize configuration UI
+  initConfigUI();
+
   // Add event listener for generate button
   document.getElementById("runBtn").addEventListener("click", generateImage);
   

--- a/js/ui.js
+++ b/js/ui.js
@@ -110,3 +110,44 @@ function initializeForm() {
   document.getElementById('strengthValue').textContent = DEFAULT_VALUES.strength;
   document.getElementById('highNoiseFracValue').textContent = DEFAULT_VALUES.highNoiseFrac;
 }
+
+function openConfig() {
+  const modal = document.getElementById('configModal');
+  if (!modal) return;
+  const stored = localStorage.getItem(CONFIG_STORAGE_KEY);
+  if (stored) {
+    try {
+      const cfg = JSON.parse(stored);
+      document.getElementById('serviceSelect').value = cfg.service || 'runpod';
+      document.getElementById('runpodId').value = cfg.runpodId || '';
+      document.getElementById('runpodKey').value = cfg.runpodKey || '';
+    } catch (e) {
+      console.error('Failed to parse config', e);
+    }
+  }
+  modal.classList.remove('hidden');
+}
+
+function closeConfig() {
+  const modal = document.getElementById('configModal');
+  if (modal) modal.classList.add('hidden');
+}
+
+function initConfigUI() {
+  const btn = document.getElementById('configBtn');
+  const saveBtn = document.getElementById('saveConfig');
+  const closeBtn = document.getElementById('closeConfig');
+  if (btn) btn.addEventListener('click', openConfig);
+  if (closeBtn) closeBtn.addEventListener('click', closeConfig);
+  if (saveBtn) {
+    saveBtn.addEventListener('click', () => {
+      const cfg = {
+        service: document.getElementById('serviceSelect').value,
+        runpodId: document.getElementById('runpodId').value.trim(),
+        runpodKey: document.getElementById('runpodKey').value.trim()
+      };
+      saveConfig(cfg);
+      closeConfig();
+    });
+  }
+}

--- a/styles/components.css
+++ b/styles/components.css
@@ -158,6 +158,42 @@
   font-weight: 600;
 }
 
+/* Config Modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 12px;
+  width: 300px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.modal-actions button {
+  width: auto;
+  margin-top: 0;
+}
+
 .image-item img {
   max-width: 100%;
   height: auto;

--- a/styles/main.css
+++ b/styles/main.css
@@ -50,6 +50,25 @@ header h1 {
   backdrop-filter: blur(10px);
 }
 
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#configBtn {
+  width: auto;
+  margin: 0;
+  padding: 10px 15px;
+  background: rgba(255,255,255,0.2);
+  border: 1px solid rgba(255,255,255,0.3);
+  box-shadow: none;
+}
+
+#configBtn:hover {
+  box-shadow: none;
+}
+
 .language-selector select option {
   background: white;
   color: #333;


### PR DESCRIPTION
## Summary
- add configurable Runpod API modal with localStorage persistence
- update scripts to load and apply saved configuration
- include header button, styles, and gitignore

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b82edee22c832581d6b099d26e99fd